### PR TITLE
allow the comma sep function to handle non-numeric values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: dfeR
 Title: Common DfE R tasks
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: c(
     person("Cam", "Race", , "cameron.race@education.gov.uk", role = c("aut", "cre")),
     person("Laura", "Selby", , "laura.selby@education.gov.uk", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dfeR 0.4.1
+
+Update comma_sep() function to allow non-numeric values instead of throwing an error, now returns them unchanged.
+
 # dfeR 0.4.0
 
 Add function which creates a DfE R project:

--- a/R/comma_sep.R
+++ b/R/comma_sep.R
@@ -1,11 +1,12 @@
 #' Comma separate
 #'
 #' @description
-#' Adds separating commas to big numbers.
+#' Adds separating commas to big numbers. If a value is not numeric it will
+#' return the value unchanged and as a string.
 #'
 #' @param number number to be comma separated
 #'
-#' @return string containing comma separated number
+#' @return string
 #' @export
 #'
 #' @examples
@@ -13,9 +14,5 @@
 #' comma_sep(1000)
 #' comma_sep(3567000)
 comma_sep <- function(number) {
-  if (!is.numeric(number)) {
-    stop("number must be a numeric value")
-  }
-
   format(number, big.mark = ",", trim = TRUE, scientific = FALSE)
 }

--- a/man/comma_sep.Rd
+++ b/man/comma_sep.Rd
@@ -10,10 +10,11 @@ comma_sep(number)
 \item{number}{number to be comma separated}
 }
 \value{
-string containing comma separated number
+string
 }
 \description{
-Adds separating commas to big numbers.
+Adds separating commas to big numbers. If a value is not numeric it will
+return the value unchanged and as a string.
 }
 \examples{
 comma_sep(100)

--- a/tests/testthat/test-comma_sep.R
+++ b/tests/testthat/test-comma_sep.R
@@ -7,17 +7,9 @@ test_that("comma separates", {
   expect_equal(comma_sep(-1000), "-1,000")
 })
 
-test_that("rejects non-numbers", {
-  expect_error(
-    comma_sep("12"),
-    "number must be a numeric value"
-  )
-  expect_error(
-    comma_sep("test"),
-    "number must be a numeric value"
-  )
-  expect_error(
-    comma_sep(TRUE),
-    "number must be a numeric value"
-  )
+test_that("handles non-numbers", {
+  expect_equal(comma_sep("12"), "12")
+  expect_equal(comma_sep("1200"), "1200")
+  expect_equal(comma_sep("test"), "test")
+  expect_equal(comma_sep(TRUE), "TRUE")
 })


### PR DESCRIPTION
# Brief overview of changes

Quick one to allow `comma_sep()` to take non numeric values.

## Why are these changes being made?

It can actually handle them fine, and this means that it can be applied over columns in data frames that have strings as well as numeric values in them.

## Detailed description of changes

Nothing to add.

## Additional information for reviewers

Potential for conflicts with #78 as I've moved the function around in there.

Known linting issue #77 that is likely to be fixed separately in #78.

I'd make this a patch version change, so if merged immediately it would bump the package to be v0.4.1. I'll add this and notes to NEWS.md after approval.

## Issue ticket number/s and link

No related issue, just made the PR as soon as I noticed.
