### PR TITLE
update get_clean_sql to ignore 'USE' lines

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,5 @@
 ^codecov\.yml$
 ^README\.Rmd$
 ^data-raw$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .DS_Store
 docs
 inst/doc
+/doc/
+/Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: dfeR
 Title: Common DfE R tasks
-Version: 0.5.0
+Version: 0.5.1
 Authors@R: c(
     person("Cam", "Race", , "cameron.race@education.gov.uk", role = c("aut", "cre")),
     person("Laura", "Selby", , "laura.selby@education.gov.uk", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dfeR 0.5.1
+
+Patch to update the get_clean_sql() function to ignorel lines starting with 'USE'.
+
 # dfeR 0.5.0
 
 Add the following lookup data sets into the package:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # dfeR 0.5.1
 
-Patch to update the get_clean_sql() function to ignorel lines starting with 'USE'.
+Patch to update the get_clean_sql() function to ignore lines starting with 'USE'.
 
 # dfeR 0.5.0
 

--- a/R/get_clean_sql.R
+++ b/R/get_clean_sql.R
@@ -44,6 +44,11 @@ get_clean_sql <- function(filepath, additional_settings = FALSE) {
     line <- gsub("\\t", " ", line)
     line <- gsub("\\n", " ", line)
 
+    # Skip over any lines that start with 'Use'
+    if (grepl("^Use", line, ignore.case = TRUE)) {
+      next
+    }
+
     if (grepl("--", line) == TRUE) {
       line <- paste(sub("--", "/*", line), "*/")
     }

--- a/man/create_time_series_lookup.Rd
+++ b/man/create_time_series_lookup.Rd
@@ -14,7 +14,7 @@ usually the output of tidy_raw_lookup}
 single data.frame of all lookup files combined
 }
 \description{
-Take a list of tidied files, likely produced by the tidy_downloaded_lookup
+Take a list of tidied files, likely produced by the tidy_raw_lookup
 function append together
 }
 \details{

--- a/tests/sql_scripts/use_example.sql
+++ b/tests/sql_scripts/use_example.sql
@@ -1,0 +1,5 @@
+-- Example SQL script use a Use call
+
+USE my_super_cool_database;
+
+SELECT * FROM [my_database_table];

--- a/tests/testthat/test-get_clean_sql.R
+++ b/tests/testthat/test-get_clean_sql.R
@@ -8,6 +8,16 @@ test_that("Can retrieve basic script", {
   )
 })
 
+test_that("Ignores USE lines", {
+  expect_equal(
+    get_clean_sql("../sql_scripts/use_example.sql"),
+    paste0(
+      " /* Example SQL script use a Use call",
+      " */   SELECT * FROM [my_database_table];"
+    )
+  )
+})
+
 test_that("Adds additional settings", {
   # Check that the output starts with the desired lines
   expect_true(

--- a/vignettes/connecting_to_sql.Rmd
+++ b/vignettes/connecting_to_sql.Rmd
@@ -74,8 +74,6 @@ Now that the SQL query is saved as a variable in the R environment you can pass 
 
 It's important to note that `dbGetQuery()` is intended to work with 'SELECT' style queries only. If you're doing something that isn't a 'SELECT' query, such as writing back into SQL, consider using the `dbExecute()` or `dbSendQuery()` functions from the [DBI package](https://dbi.r-dbi.org/) instead.
 
-
-
 ```{r executing sql query, eval=FALSE}
 sql_query_result <- DBI::dbGetQuery(con, statement = sql_query)
 ```

--- a/vignettes/connecting_to_sql.Rmd
+++ b/vignettes/connecting_to_sql.Rmd
@@ -62,6 +62,8 @@ For example, in SQL Server Management Studio (SSMS) or Azure Data Studio you mig
 
 There are a number of standard characters found in SQL scripts that can cause issues when reading in a SQL script within R and we have created the `get_clean_sql()` function to assist with this. Assume you have connected to the database and assigned that connection to a `con` variable, you would then use the following line to read a cleaned version of your SQL script into R.
 
+`get_clean_sql()` will ignore any lines of code that start with `USE` to specify a database, as your database should already be specified in your connection setup.
+
 ```{r reading clean sql, eval=FALSE}
 sql_query <- dfeR::get_clean_sql("path_to_sql_file.sql")
 ```
@@ -71,6 +73,8 @@ sql_query <- dfeR::get_clean_sql("path_to_sql_file.sql")
 Now that the SQL query is saved as a variable in the R environment you can pass that into a function to execute against the database. There's a number of potential ways to do this, though a common way is to use `dbGetQuery()` from the [DBI package](https://dbi.r-dbi.org/), setting the statement as your cleaned SQL query.
 
 It's important to note that `dbGetQuery()` is intended to work with 'SELECT' style queries only. If you're doing something that isn't a 'SELECT' query, such as writing back into SQL, consider using the `dbExecute()` or `dbSendQuery()` functions from the [DBI package](https://dbi.r-dbi.org/) instead.
+
+
 
 ```{r executing sql query, eval=FALSE}
 sql_query_result <- DBI::dbGetQuery(con, statement = sql_query)


### PR DESCRIPTION
# Brief overview of changes

Updates the `get_clean_sql()` function to ignore any lines starting with 'USE', and adds test data for it.

## Why are these changes being made?

We've recently seen an issue for a team where this line had been present and broke their pipelines, as USE specifies a database to use, but in R you usually have that database already specified in your connection. This wasted a lot of time chasing the cause, so updating this function to ignore it will help prevent similar issues in future. 

## Detailed description of changes

Pretty much what it says, the function now ignores any lines that start with `USE`.

## Additional information for reviewers

Added a note into the vignette to mention this updated behaviour too.

Also added a couple of things to git and rbuild ignore, created automatically when you run `devtools::build_vignettes()`

## Issue ticket number/s and link

No linked issue
