### PR TITLE
Improve pretty num

### DIFF
--- a/R/comma_sep.R
+++ b/R/comma_sep.R
@@ -5,6 +5,7 @@
 #' return the value unchanged and as a string.
 #'
 #' @param number number to be comma separated
+#' @param nsmall minimum number of digits to the right of the decimal point
 #'
 #' @return string
 #' @export

--- a/R/comma_sep.R
+++ b/R/comma_sep.R
@@ -16,5 +16,8 @@
 #' comma_sep(3567000)
 comma_sep <- function(number,
                       nsmall = 0L) {
-  format(number, big.mark = ",", nsmall=nsmall, trim = TRUE, scientific = FALSE)
+  format(number,
+    big.mark = ",", nsmall = nsmall, trim = TRUE,
+    scientific = FALSE
+  )
 }

--- a/R/comma_sep.R
+++ b/R/comma_sep.R
@@ -13,6 +13,7 @@
 #' comma_sep(100)
 #' comma_sep(1000)
 #' comma_sep(3567000)
-comma_sep <- function(number) {
-  format(number, big.mark = ",", trim = TRUE, scientific = FALSE)
+comma_sep <- function(number,
+                      nsmall = 0L) {
+  format(number, big.mark = ",", nsmall=nsmall, trim = TRUE, scientific = FALSE)
 }

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -213,11 +213,10 @@ pretty_time_taken <- function(start_time, end_time) {
 #' pretty_num(vector, prefix = "+/-", gbp = TRUE)
 #'
 #' # Return original values if NA
-#' pretty_num(vector,ignore_na = TRUE)
+#' pretty_num(vector, ignore_na = TRUE)
 #'
 #' # Return alternative value in place of NA
 #' pretty_num(vector, alt_na = "z")
-
 pretty_num <- function(
     value,
     prefix = "",
@@ -227,10 +226,9 @@ pretty_num <- function(
     ignore_na = FALSE,
     alt_na = FALSE,
     nsmall = NULL) {
+  # use lapply to use the function for singular value or a vector
 
-  #use lapply to use the function for singular value or a vector
-
-  result <- lapply(value, function(value){
+  result <- lapply(value, function(value) {
     # Force to numeric
     num_value <- suppressWarnings(as.numeric(value))
 
@@ -267,69 +265,50 @@ pretty_num <- function(
     # Add suffix and prefix, plus convert to million or billion
 
     # If nsmall is not given, make same value as dp
+    # if dp is smaller than 0, make nsmall 0
+    # if nsmall is specified, use that value
 
-    if(is.null(nsmall)){
-
-      nsmall <- abs(dp)
-
-      if (abs(num_value) >= 1.e9) {
-        paste0(
-          prefix,
-          currency,
-          comma_sep(round_five_up(abs(num_value) / 1.e9, dp = dp), nsmall = nsmall),
-          " billion",
-          suffix
-        )
-      } else if (abs(num_value) >= 1.e6) {
-        paste0(
-          prefix,
-          currency,
-          comma_sep(round_five_up(abs(num_value) / 1.e6, dp = dp), nsmall = nsmall),
-          " million",
-          suffix
-        )
-      } else {
-        paste0(
-          prefix,
-          currency,
-          comma_sep(round_five_up(abs(num_value), dp = dp), nsmall = nsmall),
-          suffix
-        )
-      }
-
-    }else {
-
-      # If nsmall is given, use that value
-
-      if (abs(num_value) >= 1.e9) {
-        paste0(
-          prefix,
-          currency,
-          comma_sep(round_five_up(abs(num_value) / 1.e9, dp = dp), nsmall = nsmall),
-          " billion",
-          suffix
-        )
-      } else if (abs(num_value) >= 1.e6) {
-        paste0(
-          prefix,
-          currency,
-          comma_sep(round_five_up(abs(num_value) / 1.e6, dp = dp), nsmall = nsmall),
-          " million",
-          suffix
-        )
-      } else {
-        paste0(
-          prefix,
-          currency,
-          comma_sep(round_five_up(abs(num_value), dp = dp), nsmall = nsmall),
-          suffix
-        )
-      }
+    if (!is.null(nsmall)) {
+      nsmall <- nsmall
+    } else if (dp > 0 & is.null(nsmall)) {
+      nsmall <- dp
+    } else {
+      nsmall <- 0
     }
 
-  }
-  )#lapply bracket
 
-  #unlisting the results so that they're all on one line
+    if (abs(num_value) >= 1.e9) {
+      paste0(
+        prefix,
+        currency,
+        comma_sep(round_five_up(abs(num_value) / 1.e9, dp = dp),
+          nsmall = nsmall
+        ),
+        " billion",
+        suffix
+      )
+    } else if (abs(num_value) >= 1.e6) {
+      paste0(
+        prefix,
+        currency,
+        comma_sep(round_five_up(abs(num_value) / 1.e6, dp = dp),
+          nsmall = nsmall
+        ),
+        " million",
+        suffix
+      )
+    } else {
+      paste0(
+        prefix,
+        currency,
+        comma_sep(round_five_up(abs(num_value), dp = dp),
+          nsmall = nsmall
+        ),
+        suffix
+      )
+    }
+  }) # lapply bracket
+
+  # unlisting the results so that they're all on one line
   return(unlist(result))
 }

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -202,6 +202,7 @@ pretty_time_taken <- function(start_time, end_time) {
 #' pretty_num(567812343223, gbp = TRUE, prefix = "+/-")
 #' pretty_num(11^9, gbp = TRUE, dp = 3)
 #' pretty_num(-11^8, gbp = TRUE, dp = -1)
+#' pretty_num(43.3, dp = 1, nsmall =2)
 #' pretty_num("56.089", suffix = "%")
 #' pretty_num("x")
 #' pretty_num("x", ignore_na = TRUE)

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -202,7 +202,7 @@ pretty_time_taken <- function(start_time, end_time) {
 #' pretty_num(567812343223, gbp = TRUE, prefix = "+/-")
 #' pretty_num(11^9, gbp = TRUE, dp = 3)
 #' pretty_num(-11^8, gbp = TRUE, dp = -1)
-#' pretty_num(43.3, dp = 1, nsmall =2)
+#' pretty_num(43.3, dp = 1, nsmall = 2)
 #' pretty_num("56.089", suffix = "%")
 #' pretty_num("x")
 #' pretty_num("x", ignore_na = TRUE)

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -270,7 +270,7 @@ pretty_num <- function(
 
     if(is.null(nsmall)){
 
-      nsmall <- dp
+      nsmall <- abs(dp)
 
       if (abs(num_value) >= 1.e9) {
         paste0(

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -226,104 +226,109 @@ pretty_num <- function(
     ignore_na = FALSE,
     alt_na = FALSE,
     nsmall = NULL) {
-  # Check we're only trying to prettify a single value
-  if (length(value) > 1) {
-    stop("value must be a single value, multiple values were detected")
-  }
 
-  # Force to numeric
-  num_value <- suppressWarnings(as.numeric(value))
+  #use lapply to use the function for singular value or a vector
 
-  # Check if should skip function
-  if (is.na(num_value)) {
-    if (ignore_na == TRUE) {
-      return(value) # return original value
-    } else if (alt_na != FALSE) {
-      return(alt_na) # return custom NA value
-    } else {
-      return(num_value) # return NA
-    }
-  }
+  result <- lapply(value, function(value){
+    # Force to numeric
+    num_value <- suppressWarnings(as.numeric(value))
 
-  # Convert GBP to pound symbol
-  if (gbp == TRUE) {
-    currency <- "\U00a3"
-  } else {
-    currency <- ""
-  }
-
-  # Add + / - symbols depending on size of value
-  if (prefix == "+/-") {
-    if (value >= 0) {
-      prefix <- "+"
-    } else {
-      prefix <- "-"
-    }
-    # Add in negative symbol if appropriate and not auto added with +/-
-  } else if (value < 0) {
-    prefix <- paste0("-", prefix)
-  }
-
-  # Add suffix and prefix, plus convert to million or billion
-
-  # If nsmall is not given, make same value as dp
-
-  if(is.null(nsmall)){
-
-    nsmall <- dp
-
-    if (abs(num_value) >= 1.e9) {
-      paste0(
-        prefix,
-        currency,
-        comma_sep(round_five_up(abs(num_value) / 1.e9, dp = dp), nsmall = nsmall),
-        " billion",
-        suffix
-      )
-    } else if (abs(num_value) >= 1.e6) {
-      paste0(
-        prefix,
-        currency,
-        comma_sep(round_five_up(abs(num_value) / 1.e6, dp = dp), nsmall = nsmall),
-        " million",
-        suffix
-      )
-    } else {
-      paste0(
-        prefix,
-        currency,
-        comma_sep(round_five_up(abs(num_value), dp = dp), nsmall = nsmall),
-        suffix
-      )
+    # Check if should skip function
+    if (is.na(num_value)) {
+      if (ignore_na == TRUE) {
+        return(value) # return original value
+      } else if (alt_na != FALSE) {
+        return(alt_na) # return custom NA value
+      } else {
+        return(num_value) # return NA
+      }
     }
 
-  }else {
+    # Convert GBP to pound symbol
+    if (gbp == TRUE) {
+      currency <- "\U00a3"
+    } else {
+      currency <- ""
+    }
 
-  # If nsmall is given, use that value
+    # Add + / - symbols depending on size of value
+    if (prefix == "+/-") {
+      if (value >= 0) {
+        prefix <- "+"
+      } else {
+        prefix <- "-"
+      }
+      # Add in negative symbol if appropriate and not auto added with +/-
+    } else if (value < 0) {
+      prefix <- paste0("-", prefix)
+    }
 
-  if (abs(num_value) >= 1.e9) {
-    paste0(
-      prefix,
-      currency,
-      comma_sep(round_five_up(abs(num_value) / 1.e9, dp = dp), nsmall = nsmall),
-      " billion",
-      suffix
-    )
-  } else if (abs(num_value) >= 1.e6) {
-    paste0(
-      prefix,
-      currency,
-      comma_sep(round_five_up(abs(num_value) / 1.e6, dp = dp), nsmall = nsmall),
-      " million",
-      suffix
-    )
-  } else {
-    paste0(
-      prefix,
-      currency,
-      comma_sep(round_five_up(abs(num_value), dp = dp), nsmall = nsmall),
-      suffix
-    )
+    # Add suffix and prefix, plus convert to million or billion
+
+    # If nsmall is not given, make same value as dp
+
+    if(is.null(nsmall)){
+
+      nsmall <- dp
+
+      if (abs(num_value) >= 1.e9) {
+        paste0(
+          prefix,
+          currency,
+          comma_sep(round_five_up(abs(num_value) / 1.e9, dp = dp), nsmall = nsmall),
+          " billion",
+          suffix
+        )
+      } else if (abs(num_value) >= 1.e6) {
+        paste0(
+          prefix,
+          currency,
+          comma_sep(round_five_up(abs(num_value) / 1.e6, dp = dp), nsmall = nsmall),
+          " million",
+          suffix
+        )
+      } else {
+        paste0(
+          prefix,
+          currency,
+          comma_sep(round_five_up(abs(num_value), dp = dp), nsmall = nsmall),
+          suffix
+        )
+      }
+
+    }else {
+
+      # If nsmall is given, use that value
+
+      if (abs(num_value) >= 1.e9) {
+        paste0(
+          prefix,
+          currency,
+          comma_sep(round_five_up(abs(num_value) / 1.e9, dp = dp), nsmall = nsmall),
+          " billion",
+          suffix
+        )
+      } else if (abs(num_value) >= 1.e6) {
+        paste0(
+          prefix,
+          currency,
+          comma_sep(round_five_up(abs(num_value) / 1.e6, dp = dp), nsmall = nsmall),
+          " million",
+          suffix
+        )
+      } else {
+        paste0(
+          prefix,
+          currency,
+          comma_sep(round_five_up(abs(num_value), dp = dp), nsmall = nsmall),
+          suffix
+        )
+      }
+    }
+
   }
-}
+  )#lapply bracket
+
+  #unlisting the results so that they're all on one line
+  return(unlist(result))
 }

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -209,14 +209,15 @@ pretty_time_taken <- function(start_time, end_time) {
 #'
 #' # Applied over an example vector
 #' vector <- c(3998098008, -123421421, "c", "x")
-#' unlist(lapply(vector, pretty_num))
-#' unlist(lapply(vector, pretty_num, prefix = "+/-", gbp = TRUE))
+#' pretty_num(vector)
+#' pretty_num(vector, prefix = "+/-", gbp = TRUE)
 #'
 #' # Return original values if NA
-#' unlist(lapply(vector, pretty_num, ignore_na = TRUE))
+#' pretty_num(vector,ignore_na = TRUE)
 #'
 #' # Return alternative value in place of NA
-#' unlist(lapply(vector, pretty_num, alt_na = "z"))
+#' pretty_num(vector, alt_na = "z")
+
 pretty_num <- function(
     value,
     prefix = "",

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -188,6 +188,7 @@ pretty_time_taken <- function(start_time, end_time) {
 #' @param ignore_na whether to skip function for strings that can't be
 #' converted and return original value
 #' @param alt_na alternative value to return in place of NA, e.g. "x"
+#' @param nsmall minimum number of digits to the right of the decimal point
 #'
 #' @return string featuring prettified value
 #' @family prettying
@@ -223,7 +224,8 @@ pretty_num <- function(
     suffix = "",
     dp = 2,
     ignore_na = FALSE,
-    alt_na = FALSE) {
+    alt_na = FALSE,
+    nsmall = NULL) {
   # Check we're only trying to prettify a single value
   if (length(value) > 1) {
     stop("value must be a single value, multiple values were detected")
@@ -263,11 +265,47 @@ pretty_num <- function(
   }
 
   # Add suffix and prefix, plus convert to million or billion
+
+  # If nsmall is not given, make same value as dp
+
+  if(is.null(nsmall)){
+
+    nsmall <- dp
+
+    if (abs(num_value) >= 1.e9) {
+      paste0(
+        prefix,
+        currency,
+        comma_sep(round_five_up(abs(num_value) / 1.e9, dp = dp), nsmall = nsmall),
+        " billion",
+        suffix
+      )
+    } else if (abs(num_value) >= 1.e6) {
+      paste0(
+        prefix,
+        currency,
+        comma_sep(round_five_up(abs(num_value) / 1.e6, dp = dp), nsmall = nsmall),
+        " million",
+        suffix
+      )
+    } else {
+      paste0(
+        prefix,
+        currency,
+        comma_sep(round_five_up(abs(num_value), dp = dp), nsmall = nsmall),
+        suffix
+      )
+    }
+
+  }else {
+
+  # If nsmall is given, use that value
+
   if (abs(num_value) >= 1.e9) {
     paste0(
       prefix,
       currency,
-      comma_sep(round_five_up(abs(num_value) / 1.e9, dp = dp)),
+      comma_sep(round_five_up(abs(num_value) / 1.e9, dp = dp), nsmall = nsmall),
       " billion",
       suffix
     )
@@ -275,7 +313,7 @@ pretty_num <- function(
     paste0(
       prefix,
       currency,
-      comma_sep(round_five_up(abs(num_value) / 1.e6, dp = dp)),
+      comma_sep(round_five_up(abs(num_value) / 1.e6, dp = dp), nsmall = nsmall),
       " million",
       suffix
     )
@@ -283,8 +321,9 @@ pretty_num <- function(
     paste0(
       prefix,
       currency,
-      comma_sep(round_five_up(abs(num_value), dp = dp)),
+      comma_sep(round_five_up(abs(num_value), dp = dp), nsmall = nsmall),
       suffix
     )
   }
+}
 }

--- a/man/comma_sep.Rd
+++ b/man/comma_sep.Rd
@@ -4,10 +4,12 @@
 \alias{comma_sep}
 \title{Comma separate}
 \usage{
-comma_sep(number)
+comma_sep(number, nsmall = 0L)
 }
 \arguments{
 \item{number}{number to be comma separated}
+
+\item{nsmall}{minimum number of digits to the right of the decimal point}
 }
 \value{
 string

--- a/man/pretty_num.Rd
+++ b/man/pretty_num.Rd
@@ -11,7 +11,8 @@ pretty_num(
   suffix = "",
   dp = 2,
   ignore_na = FALSE,
-  alt_na = FALSE
+  alt_na = FALSE,
+  nsmall = NULL
 )
 }
 \arguments{
@@ -30,6 +31,8 @@ assign + or - based on the value}
 converted and return original value}
 
 \item{alt_na}{alternative value to return in place of NA, e.g. "x"}
+
+\item{nsmall}{minimum number of digits to the right of the decimal point}
 }
 \value{
 string featuring prettified value
@@ -66,14 +69,14 @@ pretty_num("nope", alt_na = "x")
 
 # Applied over an example vector
 vector <- c(3998098008, -123421421, "c", "x")
-unlist(lapply(vector, pretty_num))
-unlist(lapply(vector, pretty_num, prefix = "+/-", gbp = TRUE))
+pretty_num(vector)
+pretty_num(vector, prefix = "+/-", gbp = TRUE)
 
 # Return original values if NA
-unlist(lapply(vector, pretty_num, ignore_na = TRUE))
+pretty_num(vector,ignore_na = TRUE)
 
 # Return alternative value in place of NA
-unlist(lapply(vector, pretty_num, alt_na = "z"))
+pretty_num(vector, alt_na = "z")
 }
 \seealso{
 \code{\link[=comma_sep]{comma_sep()}} \code{\link[=round_five_up]{round_five_up()}} \code{\link[=as.numeric]{as.numeric()}}

--- a/tests/testthat/test-pretty_num.R
+++ b/tests/testthat/test-pretty_num.R
@@ -25,6 +25,6 @@ test_that("handles NAs", {
 test_that("tests multiple values", {
   expect_equal(
     pretty_num(c(1:4)),
-    c("1.00" ,"2.00", "3.00" ,"4.00")
+    c("1.00", "2.00", "3.00", "4.00")
   )
 })

--- a/tests/testthat/test-pretty_num.R
+++ b/tests/testthat/test-pretty_num.R
@@ -1,17 +1,17 @@
 test_that("prettifies", {
-  expect_equal(pretty_num(1, gbp = TRUE, suffix = " offer"), "£1 offer")
-  expect_equal(pretty_num(-1), "-1")
-  expect_equal(pretty_num(-1, prefix = "-"), "--1")
-  expect_equal(pretty_num(-1, prefix = "+/-"), "-1")
-  expect_equal(pretty_num(1, prefix = "+/-"), "+1")
+  expect_equal(pretty_num(1, gbp = TRUE, suffix = " offer"), "£1.00 offer")
+  expect_equal(pretty_num(-1), "-1.00")
+  expect_equal(pretty_num(-1, prefix = "-"), "--1.00")
+  expect_equal(pretty_num(-1, prefix = "+/-"), "-1.00")
+  expect_equal(pretty_num(1, prefix = "+/-"), "+1.00")
   expect_equal(pretty_num(12.289009, suffix = "%"), "12.29%")
-  expect_equal(pretty_num(1000), "1,000")
-  expect_equal(pretty_num(11^8, gbp = TRUE, dp = -1), "£210 million")
+  expect_equal(pretty_num(1000), "1,000.00")
+  expect_equal(pretty_num(11^8, gbp = TRUE, dp = -1), "£210.0 million")
   expect_equal(pretty_num(11^9, gbp = TRUE, dp = 3), "£2.358 billion")
-  expect_equal(pretty_num(-11^8, gbp = TRUE, dp = -1), "-£210 million")
+  expect_equal(pretty_num(-11^8, gbp = TRUE, dp = -1), "-£210.0 million")
   expect_equal(pretty_num(-123421421), "-123.42 million")
   expect_equal(
-    pretty_num(11^8, prefix = "+/-", gbp = TRUE, dp = -1), "+£210 million"
+    pretty_num(11^8, prefix = "+/-", gbp = TRUE, dp = -1.00), "+£210.0 million"
   )
 })
 
@@ -22,9 +22,9 @@ test_that("handles NAs", {
   expect_equal(pretty_num("x", alt_na = "c"), "c")
 })
 
-test_that("rejects multiple values", {
+test_that("tests multiple values", {
   expect_error(
     pretty_num(c(1:4)),
-    "value must be a single value, multiple values were detected"
+    c("1.00" ,"2.00", "3.00" ,"4.00")
   )
 })

--- a/tests/testthat/test-pretty_num.R
+++ b/tests/testthat/test-pretty_num.R
@@ -10,8 +10,8 @@ test_that("prettifies", {
   expect_equal(pretty_num(11^9, gbp = TRUE, dp = 3), "£2.358 billion")
   expect_equal(pretty_num(-11^8, gbp = TRUE, dp = -1), "-£210 million")
   expect_equal(pretty_num(-123421421), "-123.42 million")
-  expect_equal(pretty_num(63.71, dp=1,nsmall=2), "63.70")
-  expect_equal(pretty_num(894.1, dp=2,nsmall=3), "894.100")
+  expect_equal(pretty_num(63.71, dp = 1, nsmall = 2), "63.70")
+  expect_equal(pretty_num(894.1, dp = 2, nsmall = 3), "894.100")
   expect_equal(
     pretty_num(11^8, prefix = "+/-", gbp = TRUE, dp = -1.00), "+£210 million"
   )
@@ -31,7 +31,7 @@ test_that("tests multiple values", {
   )
 
   expect_equal(
-    pretty_num(c(1:4), nsmall=1),
+    pretty_num(c(1:4), nsmall = 1),
     c("1.0", "2.0", "3.0", "4.0")
   )
 })

--- a/tests/testthat/test-pretty_num.R
+++ b/tests/testthat/test-pretty_num.R
@@ -6,12 +6,14 @@ test_that("prettifies", {
   expect_equal(pretty_num(1, prefix = "+/-"), "+1.00")
   expect_equal(pretty_num(12.289009, suffix = "%"), "12.29%")
   expect_equal(pretty_num(1000), "1,000.00")
-  expect_equal(pretty_num(11^8, gbp = TRUE, dp = -1), "£210.0 million")
+  expect_equal(pretty_num(11^8, gbp = TRUE, dp = -1), "£210 million")
   expect_equal(pretty_num(11^9, gbp = TRUE, dp = 3), "£2.358 billion")
-  expect_equal(pretty_num(-11^8, gbp = TRUE, dp = -1), "-£210.0 million")
+  expect_equal(pretty_num(-11^8, gbp = TRUE, dp = -1), "-£210 million")
   expect_equal(pretty_num(-123421421), "-123.42 million")
+  expect_equal(pretty_num(63.71, dp=1,nsmall=2), "63.70")
+  expect_equal(pretty_num(894.1, dp=2,nsmall=3), "894.100")
   expect_equal(
-    pretty_num(11^8, prefix = "+/-", gbp = TRUE, dp = -1.00), "+£210.0 million"
+    pretty_num(11^8, prefix = "+/-", gbp = TRUE, dp = -1.00), "+£210 million"
   )
 })
 
@@ -26,5 +28,10 @@ test_that("tests multiple values", {
   expect_equal(
     pretty_num(c(1:4)),
     c("1.00", "2.00", "3.00", "4.00")
+  )
+
+  expect_equal(
+    pretty_num(c(1:4), nsmall=1),
+    c("1.0", "2.0", "3.0", "4.0")
   )
 })

--- a/tests/testthat/test-pretty_num.R
+++ b/tests/testthat/test-pretty_num.R
@@ -23,7 +23,7 @@ test_that("handles NAs", {
 })
 
 test_that("tests multiple values", {
-  expect_error(
+  expect_equal(
     pretty_num(c(1:4)),
     c("1.00" ,"2.00", "3.00" ,"4.00")
   )


### PR DESCRIPTION
# Brief overview of changes

Changed comma_sep and pretty_num functions.

## Why are these changes being made?

To make the pretty_num function easier to use and more customisable. 

## Detailed description of changes

- Amended comma_sep by adding nsmall as an arg 
- Amended pretty_num by:
    - adding nsmall as a NULL arg and having a if loop to decide on the formatting
    - making it take single or vector values without having to use lapply and unlist outside the function 

## Issue ticket number/s and link

[Issue 82](https://github.com/dfe-analytical-services/dfeR/issues/82)
[Issue 72](https://github.com/dfe-analytical-services/dfeR/issues/72)
