### PR TITLE
Updated default dp for pretty_num

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: dfeR
 Title: Common DfE R tasks
-Version: 0.6.0
+Version: 0.6.1
 Authors@R: c(
     person("Cam", "Race", , "cameron.race@education.gov.uk", role = c("aut", "cre")),
     person("Laura", "Selby", , "laura.selby@education.gov.uk", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dfeR 0.6.1
+
+Patch to update the pretty_num() function so that the `dp` argument's default is 0. 
+
 # dfeR 0.6.0
 
 Update pretty_num so that: 

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -189,8 +189,8 @@ pretty_time_taken <- function(start_time, end_time) {
 #' converted and return original value
 #' @param alt_na alternative value to return in place of NA, e.g. "x"
 #' @param nsmall minimum number of digits to the right of the decimal point.
-#' If NULL, the value of dp will be used.
-#' If dp's value is less than 0, then nsmall will automatically be set to 0.
+#' If NULL, the value of `dp` will be used.
+#' If  value of `dp` is less than 0, then `nsmall` will automatically be set to 0.
 #'
 #' @return string featuring prettified value
 #' @family prettying

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -166,7 +166,7 @@ pretty_time_taken <- function(start_time, end_time) {
 #' Uses `as.numeric()` to force a numeric value and then formats prettily
 #' for easy presentation in console messages, reports, or dashboards.
 #'
-#' This rounds to 2 decimal places by default, and adds in comma separators.
+#' This rounds to 0 decimal places by default, and adds in comma separators.
 #'
 #' Expect that this will commonly be used for adding the pound symbol,
 #' the percentage symbol, or to have a +/- prefixed based on the value.
@@ -184,11 +184,13 @@ pretty_time_taken <- function(start_time, end_time) {
 #' assign + or - based on the value
 #' @param gbp whether to add the pound symbol or not, defaults to not
 #' @param suffix suffix for the value, e.g. "%"
-#' @param dp number of decimal places to round to, 0 by default
+#' @param dp number of decimal places to round to, 0 by default.
 #' @param ignore_na whether to skip function for strings that can't be
 #' converted and return original value
 #' @param alt_na alternative value to return in place of NA, e.g. "x"
-#' @param nsmall minimum number of digits to the right of the decimal point
+#' @param nsmall minimum number of digits to the right of the decimal point.
+#' If NULL, the value of dp will be used.
+#' If dp's value is less than 0, then nsmall will automatically be set to 0.
 #'
 #' @return string featuring prettified value
 #' @family prettying

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -184,7 +184,7 @@ pretty_time_taken <- function(start_time, end_time) {
 #' assign + or - based on the value
 #' @param gbp whether to add the pound symbol or not, defaults to not
 #' @param suffix suffix for the value, e.g. "%"
-#' @param dp number of decimal places to round to, 2 by default
+#' @param dp number of decimal places to round to, 0 by default
 #' @param ignore_na whether to skip function for strings that can't be
 #' converted and return original value
 #' @param alt_na alternative value to return in place of NA, e.g. "x"
@@ -223,7 +223,7 @@ pretty_num <- function(
     prefix = "",
     gbp = FALSE,
     suffix = "",
-    dp = 2,
+    dp = 0,
     ignore_na = FALSE,
     alt_na = FALSE,
     nsmall = NULL) {

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -190,7 +190,8 @@ pretty_time_taken <- function(start_time, end_time) {
 #' @param alt_na alternative value to return in place of NA, e.g. "x"
 #' @param nsmall minimum number of digits to the right of the decimal point.
 #' If NULL, the value of `dp` will be used.
-#' If  value of `dp` is less than 0, then `nsmall` will automatically be set to 0.
+#' If the value of `dp` is less than 0, then `nsmall` will
+#' automatically be set to 0.
 #'
 #' @return string featuring prettified value
 #' @family prettying

--- a/man/pretty_num.Rd
+++ b/man/pretty_num.Rd
@@ -25,14 +25,16 @@ assign + or - based on the value}
 
 \item{suffix}{suffix for the value, e.g. "\%"}
 
-\item{dp}{number of decimal places to round to, 0 by default}
+\item{dp}{number of decimal places to round to, 0 by default.}
 
 \item{ignore_na}{whether to skip function for strings that can't be
 converted and return original value}
 
 \item{alt_na}{alternative value to return in place of NA, e.g. "x"}
 
-\item{nsmall}{minimum number of digits to the right of the decimal point}
+\item{nsmall}{minimum number of digits to the right of the decimal point.
+If NULL, the value of dp will be used.
+If dp's value is less than 0, then nsmall will automatically be set to 0.}
 }
 \value{
 string featuring prettified value
@@ -41,7 +43,7 @@ string featuring prettified value
 Uses \code{as.numeric()} to force a numeric value and then formats prettily
 for easy presentation in console messages, reports, or dashboards.
 
-This rounds to 2 decimal places by default, and adds in comma separators.
+This rounds to 0 decimal places by default, and adds in comma separators.
 
 Expect that this will commonly be used for adding the pound symbol,
 the percentage symbol, or to have a +/- prefixed based on the value.

--- a/man/pretty_num.Rd
+++ b/man/pretty_num.Rd
@@ -33,8 +33,8 @@ converted and return original value}
 \item{alt_na}{alternative value to return in place of NA, e.g. "x"}
 
 \item{nsmall}{minimum number of digits to the right of the decimal point.
-If NULL, the value of dp will be used.
-If dp's value is less than 0, then nsmall will automatically be set to 0.}
+If NULL, the value of \code{dp} will be used.
+If  value of \code{dp} is less than 0, then \code{nsmall} will automatically be set to 0.}
 }
 \value{
 string featuring prettified value

--- a/man/pretty_num.Rd
+++ b/man/pretty_num.Rd
@@ -9,7 +9,7 @@ pretty_num(
   prefix = "",
   gbp = FALSE,
   suffix = "",
-  dp = 2,
+  dp = 0,
   ignore_na = FALSE,
   alt_na = FALSE,
   nsmall = NULL
@@ -25,7 +25,7 @@ assign + or - based on the value}
 
 \item{suffix}{suffix for the value, e.g. "\%"}
 
-\item{dp}{number of decimal places to round to, 2 by default}
+\item{dp}{number of decimal places to round to, 0 by default}
 
 \item{ignore_na}{whether to skip function for strings that can't be
 converted and return original value}

--- a/tests/testthat/test-pretty_num.R
+++ b/tests/testthat/test-pretty_num.R
@@ -1,19 +1,21 @@
 test_that("prettifies", {
-  expect_equal(pretty_num(1, gbp = TRUE, suffix = " offer"), "£1.00 offer")
-  expect_equal(pretty_num(-1), "-1.00")
-  expect_equal(pretty_num(-1, prefix = "-"), "--1.00")
-  expect_equal(pretty_num(-1, prefix = "+/-"), "-1.00")
-  expect_equal(pretty_num(1, prefix = "+/-"), "+1.00")
-  expect_equal(pretty_num(12.289009, suffix = "%"), "12.29%")
-  expect_equal(pretty_num(1000), "1,000.00")
+  expect_equal(pretty_num(1, gbp = TRUE, suffix = " offer"), "£1 offer")
+  expect_equal(pretty_num(-1,dp=2), "-1.00")
+  expect_equal(pretty_num(-1), "-1")
+  expect_equal(pretty_num(-1, prefix = "-"), "--1")
+  expect_equal(pretty_num(-1, prefix = "+/-"), "-1")
+  expect_equal(pretty_num(-1,dp=2, prefix = "+/-"), "-1.00")
+  expect_equal(pretty_num(1, prefix = "+/-"), "+1")
+  expect_equal(pretty_num(12.289009,dp=2, suffix = "%"), "12.29%")
+  expect_equal(pretty_num(1000), "1,000")
   expect_equal(pretty_num(11^8, gbp = TRUE, dp = -1), "£210 million")
   expect_equal(pretty_num(11^9, gbp = TRUE, dp = 3), "£2.358 billion")
   expect_equal(pretty_num(-11^8, gbp = TRUE, dp = -1), "-£210 million")
-  expect_equal(pretty_num(-123421421), "-123.42 million")
+  expect_equal(pretty_num(-123421421,dp=2), "-123.42 million")
   expect_equal(pretty_num(63.71, dp = 1, nsmall = 2), "63.70")
   expect_equal(pretty_num(894.1, dp = 2, nsmall = 3), "894.100")
   expect_equal(
-    pretty_num(11^8, prefix = "+/-", gbp = TRUE, dp = -1.00), "+£210 million"
+    pretty_num(11^8, prefix = "+/-", gbp = TRUE, dp = -1), "+£210 million"
   )
 })
 
@@ -27,11 +29,16 @@ test_that("handles NAs", {
 test_that("tests multiple values", {
   expect_equal(
     pretty_num(c(1:4)),
-    c("1.00", "2.00", "3.00", "4.00")
+    c("1", "2", "3", "4")
   )
 
   expect_equal(
     pretty_num(c(1:4), nsmall = 1),
     c("1.0", "2.0", "3.0", "4.0")
+  )
+
+  expect_equal(
+    pretty_num(c(1.478,7.38897,8.37892), dp=1, nsmall=2),
+    c("1.50", "7.40", "8.40")
   )
 })

--- a/tests/testthat/test-pretty_num.R
+++ b/tests/testthat/test-pretty_num.R
@@ -1,17 +1,17 @@
 test_that("prettifies", {
   expect_equal(pretty_num(1, gbp = TRUE, suffix = " offer"), "£1 offer")
-  expect_equal(pretty_num(-1,dp=2), "-1.00")
+  expect_equal(pretty_num(-1, dp = 2), "-1.00")
   expect_equal(pretty_num(-1), "-1")
   expect_equal(pretty_num(-1, prefix = "-"), "--1")
   expect_equal(pretty_num(-1, prefix = "+/-"), "-1")
-  expect_equal(pretty_num(-1,dp=2, prefix = "+/-"), "-1.00")
+  expect_equal(pretty_num(-1, dp = 2, prefix = "+/-"), "-1.00")
   expect_equal(pretty_num(1, prefix = "+/-"), "+1")
-  expect_equal(pretty_num(12.289009,dp=2, suffix = "%"), "12.29%")
+  expect_equal(pretty_num(12.289009, dp = 2, suffix = "%"), "12.29%")
   expect_equal(pretty_num(1000), "1,000")
   expect_equal(pretty_num(11^8, gbp = TRUE, dp = -1), "£210 million")
   expect_equal(pretty_num(11^9, gbp = TRUE, dp = 3), "£2.358 billion")
   expect_equal(pretty_num(-11^8, gbp = TRUE, dp = -1), "-£210 million")
-  expect_equal(pretty_num(-123421421,dp=2), "-123.42 million")
+  expect_equal(pretty_num(-123421421, dp = 2), "-123.42 million")
   expect_equal(pretty_num(63.71, dp = 1, nsmall = 2), "63.70")
   expect_equal(pretty_num(894.1, dp = 2, nsmall = 3), "894.100")
   expect_equal(
@@ -38,7 +38,7 @@ test_that("tests multiple values", {
   )
 
   expect_equal(
-    pretty_num(c(1.478,7.38897,8.37892), dp=1, nsmall=2),
+    pretty_num(c(1.478, 7.38897, 8.37892), dp = 1, nsmall = 2),
     c("1.50", "7.40", "8.40")
   )
 })

--- a/tests/testthat/test-pretty_num_table.R
+++ b/tests/testthat/test-pretty_num_table.R
@@ -8,20 +8,20 @@ df <- data.frame(
 
 
 test_that("prettifies tables", {
-  expect_equal(pretty_num_table(df,dp=2), data.frame(
+  expect_equal(pretty_num_table(df, dp = 2), data.frame(
     a = c("2.59", "-5.89", as.double(NA)),
     b = c("11.20", "45.69", "-78.50"),
     c = c(as.double(NA), as.double(NA), as.double(NA))
   ))
 
-  expect_equal(pretty_num_table(df,dp=3), data.frame(
+  expect_equal(pretty_num_table(df, dp = 3), data.frame(
     a = c("2.589", "-5.894", as.double(NA)),
     b = c("11.199", "45.689", "-78.499"),
     c = c(as.double(NA), as.double(NA), as.double(NA))
   ))
 
   expect_equal(
-    pretty_num_table(df,dp=2, gbp = TRUE, exclude_columns = "c"),
+    pretty_num_table(df, dp = 2, gbp = TRUE, exclude_columns = "c"),
     data.frame(
       a = c("£2.59", "-£5.89", as.double(NA)),
       b = c("£11.20", "£45.69", "-£78.50"),

--- a/tests/testthat/test-pretty_num_table.R
+++ b/tests/testthat/test-pretty_num_table.R
@@ -8,17 +8,32 @@ df <- data.frame(
 
 
 test_that("prettifies tables", {
-  expect_equal(pretty_num_table(df), data.frame(
+  expect_equal(pretty_num_table(df,dp=2), data.frame(
     a = c("2.59", "-5.89", as.double(NA)),
     b = c("11.20", "45.69", "-78.50"),
     c = c(as.double(NA), as.double(NA), as.double(NA))
   ))
 
+  expect_equal(pretty_num_table(df,dp=3), data.frame(
+    a = c("2.589", "-5.894", as.double(NA)),
+    b = c("11.199", "45.689", "-78.499"),
+    c = c(as.double(NA), as.double(NA), as.double(NA))
+  ))
+
   expect_equal(
-    pretty_num_table(df, gbp = TRUE, exclude_columns = "c"),
+    pretty_num_table(df,dp=2, gbp = TRUE, exclude_columns = "c"),
     data.frame(
       a = c("£2.59", "-£5.89", as.double(NA)),
       b = c("£11.20", "£45.69", "-£78.50"),
+      c = c("X", "Y", "Z")
+    )
+  )
+
+  expect_equal(
+    pretty_num_table(df, gbp = TRUE, exclude_columns = "c"),
+    data.frame(
+      a = c("£3", "-£6", as.double(NA)),
+      b = c("£11", "£46", "-£78"),
       c = c("X", "Y", "Z")
     )
   )


### PR DESCRIPTION


# Brief overview of changes

- Changed default dp in pretty_num from 2 to 0 
- Amended tests for pretty_num and pretty_num_table

## Why are these changes being made?

To stop the change in behaviour in pretty_num in the v0.6.0. This bug forces 2 dp by default. 

## Detailed description of changes

-  Reverted tests for pretty_num to original ones and added more tests for dp
-  Amended tests in pretty_num_table to reflect the changes made in pretty num 
-  Updated documentation 

## Issue ticket number/s and link

[92](https://github.com/dfe-analytical-services/dfeR/issues/92)
