### PR TITLE
add downloads badge

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -20,6 +20,7 @@ knitr::opts_chunk$set(
 [![pkgdown](https://github.com/dfe-analytical-services/dfeR/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/dfe-analytical-services/dfeR/actions/workflows/pkgdown.yaml)
 [![Codecov test coverage](https://codecov.io/gh/dfe-analytical-services/dfeR/graph/badge.svg)](https://app.codecov.io/gh/dfe-analytical-services/dfeR)
 [![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-green.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
+[![](https://cranlogs.r-pkg.org/badges/dfeR)](https://cran.r-project.org/package=dfeR)
 <!-- badges: end -->
 
 The goal of dfeR is to help standardise R programming across the Department for Education (DfE), and facilitate sharing of business specific functions, making our code easier to read and write.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 coverage](https://codecov.io/gh/dfe-analytical-services/dfeR/graph/badge.svg)](https://app.codecov.io/gh/dfe-analytical-services/dfeR)
 [![Lifecycle:
 stable](https://img.shields.io/badge/lifecycle-stable-green.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
+[![](https://cranlogs.r-pkg.org/badges/dfeR)](https://cran.r-project.org/package=dfeR)
 <!-- badges: end -->
 
 The goal of dfeR is to help standardise R programming across the


### PR DESCRIPTION
# Brief overview of changes

Quick one while I was tidying up for the week, noticed that it was pretty easy to track CRAN downloads using https://github.com/r-hub/cranlogs.app

## Why are these changes being made?

Figured it might be useful to track usage of the package, particularly if we add more and try to grow it, we have a mostly limited audience, but we're also statisticians and love data 🤷 

## Detailed description of changes

Badge on README showing downloads for the last month.

## Additional information for reviewers

I also have a script to pull out the numbers over time, so at some point in future if we want we can plot that and analyse it.

## Issue ticket number/s and link

No related issues.
