### PR TITLE
Correct spell_check_package() function name in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -87,7 +87,7 @@ styler::style_pkg()
 ``` r
 devtools::check() # General package check, can also use Ctrl-Shift-E
 lintr::lint_package() # Check formatting of code
-spelling::spell_check() # Check for spelling mistakes
+spelling::spell_check_package() # Check for spelling mistakes
 ```
 
 ## Handy workflows


### PR DESCRIPTION
# Brief overview of changes
Changed the name of the spell_check_package() function to correct a typo

## Why are these changes being made?
The spelling::spell_check() function doesn't exist so had to be changed to spelling:spell_check_package()

## Detailed description of changes

## Additional information for reviewers

## Issue ticket number/s and link
Issue #97
https://github.com/dfe-analytical-services/dfeR/issues/97