### PR TITLE
Add argument to pretty_num function to determine whether value input …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Authors@R: c(
     person("Rich", "Bielby", , "richard.bielby@education.gov.uk", role = "ctb",
            comment = c(ORCID = "0000-0001-9070-9969")),
     person("Menna", "Zayed", , "menna.zayed@education.gov.uk", role = "ctb"),
-    person("Lauren", "Snaathorst", , "lauren.snaathorst@education.gov.uk", role = "ctb")
+    person("Lauren", "Snaathorst", , "lauren.snaathorst@education.gov.uk", role = "ctb"),
+    person("Lara", "Garbett", , "lara.garbett@education.gov.uk", role = "ctb")
   )
 Description: Preferred methods for common analytical tasks that are
     undertaken across the Department, including number formatting, project

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # dfeR (development version)
 
 - Updated `geo_hierarchy`, and associated `fetch_*` functions with latest 2025 lookups.
+- Updated `pretty_num()` function to add `abbreviate` argument giving the option to avoid displaying large numbers in millions/billions.
 
 # dfeR 1.2.0
 

--- a/R/pretty.R
+++ b/R/pretty.R
@@ -232,6 +232,8 @@ pretty_time_taken <- function(start_time, end_time) {
 #' If NULL, the value of `dp` will be used.
 #' If the value of `dp` is less than 0, then `nsmall` will
 #' automatically be set to 0.
+#' @param abbreviate whether to abbreviate large numbers to nearest million
+#' (where 1e6 <= value < 1e9) or billion (where value >= 1e9).
 #'
 #' @return string featuring prettified value
 #' @family prettying
@@ -250,6 +252,7 @@ pretty_time_taken <- function(start_time, end_time) {
 #' pretty_num("x")
 #' pretty_num("x", ignore_na = TRUE)
 #' pretty_num("nope", alt_na = "x")
+#' pretty_num(7.8e9, abbreviate = FALSE)
 #'
 #' # Applied over an example vector
 #' vector <- c(3998098008, -123421421, "c", "x")
@@ -269,7 +272,8 @@ pretty_num <- function(
     dp = 0,
     ignore_na = FALSE,
     alt_na = FALSE,
-    nsmall = NULL) {
+    nsmall = NULL,
+    abbreviate = TRUE) {
   # use lapply to use the function for singular value or a vector
 
   result <- lapply(value, function(value) {
@@ -322,7 +326,7 @@ pretty_num <- function(
     }
 
 
-    if (abs(num_value) >= 1.e9) {
+    if (abs(num_value) >= 1.e9 & abbreviate == TRUE) {
       paste0(
         prefix,
         currency,
@@ -332,7 +336,7 @@ pretty_num <- function(
         " billion",
         suffix
       )
-    } else if (abs(num_value) >= 1.e6) {
+    } else if (abs(num_value) >= 1.e6 & abbreviate == TRUE) {
       paste0(
         prefix,
         currency,

--- a/man/dfeR-package.Rd
+++ b/man/dfeR-package.Rd
@@ -36,6 +36,7 @@ Other contributors:
   \item Rich Bielby \email{richard.bielby@education.gov.uk} (\href{https://orcid.org/0000-0001-9070-9969}{ORCID}) [contributor]
   \item Menna Zayed \email{menna.zayed@education.gov.uk} [contributor]
   \item Lauren Snaathorst \email{lauren.snaathorst@education.gov.uk} [contributor]
+  \item Lara Garbett \email{lara.garbett@education.gov.uk} [contributor]
 }
 
 }

--- a/man/pretty_num.Rd
+++ b/man/pretty_num.Rd
@@ -12,7 +12,8 @@ pretty_num(
   dp = 0,
   ignore_na = FALSE,
   alt_na = FALSE,
-  nsmall = NULL
+  nsmall = NULL,
+  abbreviate = TRUE
 )
 }
 \arguments{
@@ -36,6 +37,9 @@ converted and return original value}
 If NULL, the value of \code{dp} will be used.
 If the value of \code{dp} is less than 0, then \code{nsmall} will
 automatically be set to 0.}
+
+\item{abbreviate}{whether to abbreviate large numbers to nearest million
+(where 1e6 <= value < 1e9) or billion (where value >= 1e9).}
 }
 \value{
 string featuring prettified value
@@ -70,6 +74,7 @@ pretty_num("56.089", suffix = "\%")
 pretty_num("x")
 pretty_num("x", ignore_na = TRUE)
 pretty_num("nope", alt_na = "x")
+pretty_num(7.8e9, abbreviate = FALSE)
 
 # Applied over an example vector
 vector <- c(3998098008, -123421421, "c", "x")

--- a/tests/testthat/test-pretty_num.R
+++ b/tests/testthat/test-pretty_num.R
@@ -17,6 +17,9 @@ test_that("prettifies", {
   expect_equal(
     pretty_num(11^8, prefix = "+/-", gbp = TRUE, dp = -1), "+£210 million"
   )
+  expect_equal(pretty_num(7.8e9, abbreviate = FALSE), "7,800,000,000")
+  expect_equal(pretty_num(7.8e9, dp = 1, abbreviate = FALSE), "7,800,000,000.0")
+  expect_equal(pretty_num(-3e6, gbp = TRUE, abbreviate = FALSE), "-£3,000,000")
 })
 
 test_that("handles NAs", {


### PR DESCRIPTION
…is abbreviated to millions/billions (#120)

* Add argument to pretty_num function to determine whether value input is abbreviated to nearest million/billion.

* Add myself as contributor in DESCRIPTION file; add description of change to NEWS.md; add extra test cases for pretty_num() to cover "abbreviate" argument; add example using "abbreviate" argument into docs.

* Shorten a line to be no more than 80 characters to pass lint_package() test

---------

<!-- 
Hey, thanks for raising a PR! We're excited to see what you've done!
To help us review the changes, please complete each section in this template by replacing '...' with details to help the reviewers of this pull request. 
-->

# Brief overview of changes

...

## Why are these changes being made?

...

## Detailed description of changes

...

## Additional information for reviewers

...

## Issue ticket number/s and link

...
