### PR TITLE
Amended readme for more clear instructions on downloading the package

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -55,15 +55,24 @@ While we have some DfE specific data in the dfeR package taken from the [Open Ge
 
 ## Installation
 
-dfeR is available on CRAN and you can install directly from there:
+### Install CRAN version
+
+dfeR is available on CRAN and can be installed using [pak](https://pak.r-lib.org/) for faster and more reliable package installation.
+
+
+Then install dfeR from CRAN:
 
 ``` r
-install.packages("dfeR")
+# If you don’t have pak installed yet, install it first using
+# install.packages("pak") is required 
+pak::pak("dfeR")
 ```
 
-You can install the development version from GitHub.
+### Install development version from GitHub
 
-If you are using [renv](https://rstudio.github.io/renv/articles/renv.html) in your project (recommended):
+If you are using
+[renv](https://rstudio.github.io/renv/articles/renv.html) in your
+project (recommended):
 
 ``` r
 renv::install("dfe-analytical-services/dfeR")
@@ -72,9 +81,11 @@ renv::install("dfe-analytical-services/dfeR")
 Otherwise:
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("dfe-analytical-services/dfeR")
+# If you don’t have pak installed yet, install it first using
+# install.packages("pak") 
+pak::pak("dfe-analytical-services/dfeR")
 ```
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -65,13 +65,20 @@ gives more functions for directly extracting data from there.
 
 ## Installation
 
-dfeR is available on CRAN and you can install directly from there:
+### Install CRAN version
+
+dfeR is available on CRAN and can be installed using [pak](https://pak.r-lib.org/) for faster and more reliable package installation.
+
+
+Then install dfeR from CRAN:
 
 ``` r
-install.packages("dfeR")
+# If you don’t have pak installed yet, install it first using
+# install.packages("pak") 
+pak::pak("dfeR")
 ```
 
-You can install the development version from GitHub.
+### Install development version from GitHub
 
 If you are using
 [renv](https://rstudio.github.io/renv/articles/renv.html) in your
@@ -84,10 +91,10 @@ renv::install("dfe-analytical-services/dfeR")
 Otherwise:
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("dfe-analytical-services/dfeR")
+# If you don’t have pak installed yet, install it first using
+# install.packages("pak") 
+pak::pak("dfe-analytical-services/dfeR")
 ```
-
 ------------------------------------------------------------------------
 
 ## Proxy


### PR DESCRIPTION
# Brief overview of changes

Amended readme for the repo and pkgdown site to update instructions for installing the package to make it more clear around renv environment installs and recommend using pak.

## Why are these changes being made?

Users encounter errors when installing development version using the normal method and I wanted to improve the clarity of the guidance. 

## Detailed description of changes

Restructured the instructions with subheadings to make them easier to spot and updated them to reflect pak.  


## Issue ticket number/s and link

[123](https://github.com/dfe-analytical-services/dfeR/issues/123)